### PR TITLE
Simplify fragment lookup with `dict.get()`

### DIFF
--- a/CommLog.py
+++ b/CommLog.py
@@ -181,10 +181,7 @@ class CommLog:
         """Returns what transfer protocol has used to transmit a fragment
         "xmodem", "ymodem", "raw" or "unknown"
         """
-        if fragment_name in list(self.file_transfer_method.keys()):
-            return self.file_transfer_method[fragment_name]
-        else:
-            return "unknown"
+        return self.file_transfer_method.get(fragment_name, "unknown")
 
     def get_fragment_dictionary(self):
         """Returns a dictionary that maps a dive num to a fragment size"""


### PR DESCRIPTION
# Simplify Fragment Lookup with `dict.get()`

Hello, I was observing your code and perceived a change that could be useful:

## Description
This PR refactors `find_fragment_transfer_method` to use `dict.get()` instead of an `if` check with `list(self.file_transfer_method.keys())`. It’s a small but smart improvement for cleaner, more efficient code.

## Why This Change?
The original code converted `dict.keys()` to a `list` and checked membership with `in`, which is O(n). Using `dict.get()` leverages the dictionary’s O(1) lookup directly—faster and more Pythonic. While the performance gain may not be drastic for small datasets, it’s a logical optimization that scales better and aligns with best practices.

## No Logic Changes
The behavior stays the same—returning the transfer method or `"unknown"` if not found. Only the implementation is cleaner:
- **Before**: `if fragment_name in list(self.file_transfer_method.keys())`
- **After**: `return self.file_transfer_method.get(fragment_name, "unknown")`

## Benefits
- **Performance**: O(1) lookup vs O(n).
- **Clarity**: No unnecessary list conversion or `if` statement.
- **Readability**: More concise and idiomatic Python.